### PR TITLE
修复network.ts中的post请求并提供x-www-form-urlencoded的调用方法

### DIFF
--- a/bilibili-api-ts/utils/network.ts
+++ b/bilibili-api-ts/utils/network.ts
@@ -112,7 +112,7 @@ export async function request(
   };
   var headers = DEFAULT_HEADERS;
 
-  if (!no_csrf && method in ["POST", "DELETE", "PATCH"]){
+  if (!no_csrf && ["POST", "DELETE", "PATCH"].includes(method)){
     if (data === null){
       data = {};
     }

--- a/bilibili-api-ts/utils/network.ts
+++ b/bilibili-api-ts/utils/network.ts
@@ -81,7 +81,7 @@ export async function get_session({credential=new Credential({})}: {credential: 
 
 export async function request(
   {
-    method, url, params={}, data={}, credential=new Credential({}), no_csrf=false
+    method, url, params={}, data={}, credential=new Credential({}), no_csrf=false, useFormUrlEncoded=false
   } : 
   {
     method: string, 
@@ -89,7 +89,8 @@ export async function request(
     params?: any, 
     data?: any, 
     credential?: Credential|null, 
-    no_csrf?: boolean
+    no_csrf?: boolean,
+    useFormUrlEncoded?: boolean,
   }
 ) {
   if (no_csrf === null || no_csrf === undefined) {
@@ -118,6 +119,10 @@ export async function request(
     }
     data["csrf"] = credential.bili_jct;
     data["csrf_token"] = credential.bili_jct;
+    if (useFormUrlEncoded) {
+      headers['content-type'] = 'application/x-www-form-urlencoded';
+      data = stringify(data);
+    }
   }
 
   if (params === null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "lib": ["ESNext"],
         "outDir": ".",
         "declaration": true,
         "declarationDir": "."


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# 修复network.ts中的post请求并提供x-www-form-urlencoded的调用方法
- 1. network.ts下的request增加`useFormUrlEncoded`参数，默认为`false`，第一是加入`x-www-form-urlencoded`所需的请求头，第二是对data做数据转化
- 2. network.ts下的post请求判断写错了，js的关键词`in`的作用，是判断一个对象中是否有这个key，比如`"a" in {a: 1}`，而字符串的判断是`includes`，用`method in ["POST", "DELETE", "PATCH"]`，明显有问题
- 3. 这个库里真的是一个post请求都没有啊，那`Credential`还有啥用...而且python那边的有个刷新cookie的机制，js这里也没有...我还挺需要的，不行的话我后面看看能不能再提下pr吧
